### PR TITLE
Add automatic build of docker image to github packages

### DIFF
--- a/.github/workflows/mapstore.yml
+++ b/.github/workflows/mapstore.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: "checking out"
       uses: actions/checkout@v2
@@ -86,32 +89,33 @@ jobs:
         path: scratch/mapstore-${{ github.sha }}.war
 
     - name: Getting image tag
-      if: github.repository == 'georchestra/mapstore2-georchestra'
+      if: github.repository == 'geo2france/mapstore2-georchestra'
       id: version
       run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
     - name: "Building docker image"
-      if: github.repository == 'georchestra/mapstore2-georchestra'
+      if: github.repository == 'geo2france/mapstore2-georchestra'
       run: |
         cp scratch/mapstore-${{ github.sha }}.war docker/MapStore-${{ steps.version.outputs.VERSION }}.war
-        docker build . -t georchestra/mapstore:${{ steps.version.outputs.VERSION }}
+        docker build . -t ghcr.io/geo2france/mapstore2-georchestra:${{ steps.version.outputs.VERSION }}
         # mvn -B package dockerfile:build -Pdocker,log4j-logstash,sentry-log4j -DdockerImageName=georchestra/mapstore:${{ steps.version.outputs.VERSION }} -settings settings.xml
       working-directory: ${{ github.workspace }}
     - name: "Logging in docker.io"
-      if: github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
+      if: github.repository == 'geo2france/mapstore2-georchestra' && github.event_name == 'push'
       uses: azure/docker-login@v1
       with:
-        username: '${{ secrets.DOCKER_HUB_USERNAME }}'
-        password: '${{ secrets.DOCKER_HUB_PASSWORD }}'
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
 
-    - name: "Pushing latest to docker.io"
-      if: github.ref == 'refs/heads/master' && github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
+    - name: "Pushing 2023.02.xx-custom to docker.io"
+      if: github.ref == '2023.02.xx-custom' && github.repository == 'geo2france/mapstore2-georchestra' && github.event_name == 'push'
       run: |
-        docker tag georchestra/mapstore:${{ steps.version.outputs.VERSION }} georchestra/mapstore:latest
-        docker push georchestra/mapstore:latest
+        docker tag ghcr.io/geo2france/mapstore2-georchestra:${{ steps.version.outputs.VERSION }} ghcr.io/geo2france/mapstore2-georchestra:2023.02.xx-custom
+        docker push ghcr.io/geo2france/mapstore2-georchestra:2023.02.xx-custom
       working-directory: ${{ github.workspace }}
 
     - name: "Pushing tag to docker.io"
-      if: contains(github.ref, 'refs/tags/') && github.repository == 'georchestra/mapstore2-georchestra' && github.event_name == 'push'
+      if: contains(github.ref, 'refs/tags/') && github.repository == 'geo2france/mapstore2-georchestra' && github.event_name == 'push'
       run: |
-        docker push georchestra/mapstore:${{ steps.version.outputs.VERSION }}
+        docker push ghcr.io/geo2france/mapstore2-georchestra:${{ steps.version.outputs.VERSION }}


### PR DESCRIPTION
This will automatically build in Docker all new changes done in https://github.com/geo2france/mapstore2-georchestra/tree/2023.02.xx-custom to GitHub packages registry where it will be accessible from the public.

Accessible URL for docker: ghcr.io/geo2france/mapstore2-georchestra:2023.02.xx-custom